### PR TITLE
Allow link number colors to be changed.

### DIFF
--- a/src/config/options.inc
+++ b/src/config/options.inc
@@ -621,6 +621,15 @@ static union option_info config_options_info[] = {
 		"\n"
 		"See document.browse.links.color_dirs option.")),
 
+	INIT_OPT_BOOL("document.colors", N_("Use link number color"),
+	        "use_link_number_color", 0, 0,
+		N_("Whether to use link number color even when colors "
+		"specified by the document are used.")),
+
+	INIT_OPT_COLOR("document.colors", N_("Link number color"),
+		"link_number", 0, "#0000ff",
+		N_("Default link number color.")),
+
 	/* Compatibility alias: added by jonas at 2005-05-31, 0.11.CVS. */
 	INIT_OPT_ALIAS("document.colors", "allow_dark_on_black", OPT_ALIAS_NEGATE,
 		"document.colors.increase_contrast"),

--- a/src/document/html/parser.c
+++ b/src/document/html/parser.c
@@ -799,6 +799,7 @@ init_html_parser(struct uri *uri, struct document_options *options,
 	format.color.bookmark_link = options->default_color.bookmark_link;
 #endif
 	format.color.image_link = options->default_color.image_link;
+	format.color.link_number = options->default_color.link_number;
 
 	par_format.align = ALIGN_LEFT;
 	par_format.leftmargin = options->margin;

--- a/src/document/html/parser.h
+++ b/src/document/html/parser.h
@@ -30,6 +30,7 @@ struct text_attrib_color {
 	color_T bookmark_link;
 #endif
 	color_T image_link;
+	color_T link_number;
 };
 
 struct text_attrib {

--- a/src/document/html/renderer.c
+++ b/src/document/html/renderer.c
@@ -1611,12 +1611,17 @@ put_link_number(struct html_context *html_context)
 	unsigned char *fl = format.link;
 	unsigned char *ft = format.target;
 	unsigned char *fi = format.image;
+	struct text_style old_style = format.style;
 	struct form_control *ff = format.form;
 	int slen = 0;
 	int base = strlen(symkey);
 
 	format.link = format.target = format.image = NULL;
 	format.form = NULL;
+	if (html_context->options->use_link_number_color) {
+		format.style.attr &= ~AT_BOLD;
+		format.style.color.foreground = format.color.link_number;
+	}
 
 	s[slen++] = '[';
 	slen += dec2qwerty(part->link_num, s + 1, symkey, base);
@@ -1637,6 +1642,7 @@ put_link_number(struct html_context *html_context)
 	format.target = ft;
 	format.image = fi;
 	format.form = ff;
+	format.style = old_style;
 }
 
 #define assert_link_variable(old, new) \

--- a/src/document/options.c
+++ b/src/document/options.c
@@ -45,6 +45,8 @@ init_document_options(struct session *ses, struct document_options *doo)
 	doo->default_color.bookmark_link = get_opt_color("document.colors.bookmark", ses);
 #endif
 	doo->default_color.image_link = get_opt_color("document.colors.image", ses);
+	doo->default_color.link_number = get_opt_color("document.colors.link_number", ses);
+	doo->use_link_number_color = doo->use_document_colors == 0 || get_opt_bool("document.colors.use_link_number_color", ses);
 
 	doo->active_link.color.foreground = get_opt_color("document.browse.links.active_link.colors.text", ses);
 	doo->active_link.color.background = get_opt_color("document.browse.links.active_link.colors.background", ses);

--- a/src/document/options.h
+++ b/src/document/options.h
@@ -32,6 +32,7 @@ struct document_options_colors {
 	color_T bookmark_link;
 #endif
 	color_T image_link;
+	color_T link_number;
 };
 
 struct document_options_image_link {
@@ -61,6 +62,8 @@ struct document_options {
 	struct text_style default_style;
 	struct document_options_colors default_color;
 	/** @} */
+
+	unsigned int use_link_number_color:1;
 
 	/** Color model/optimizations */
 	enum color_flags color_flags;


### PR DESCRIPTION
These settings are specified by

  document.colors.link_number
  document.colors.use_link_number_color

The latter setting determines whether the color is used when document
colors are being used.

See bug #1050.