### PR TITLE
Provide different color for text areas in insert mode.

### DIFF
--- a/src/config/options.inc
+++ b/src/config/options.inc
@@ -294,6 +294,18 @@ static union option_info config_options_info[] = {
 		"text", 0, "black",
 		N_("Default text color.")),
 
+	INIT_OPT_TREE("document.browse.links.active_link", N_("Insert mode colors"),
+		"insert_mode_colors", 0,
+		N_("Insert mode colors.")),
+
+	INIT_OPT_COLOR("document.browse.links.active_link.insert_mode_colors", N_("Background color for text field in insert mode"),
+		"background", 0, "#0000ff",
+		N_("Background color for text field in insert mode")),
+
+	INIT_OPT_COLOR("document.browse.links.active_link.insert_mode_colors", N_("Text color for text field in insert mode"),
+		"text", 0, "black",
+		N_("Text color for text field in insert mode.")),
+
 	INIT_OPT_BOOL("document.browse.links.active_link", N_("Enable color"),
 		"enable_color", 0, 0,
 		N_("Enable use of the active link background and text color "

--- a/src/document/document.c
+++ b/src/document/document.c
@@ -312,6 +312,8 @@ update_cached_document_options(struct session *ses)
 	memset(&active_link, 0, sizeof(active_link));	/* Safer. */
 	active_link.color.foreground = get_opt_color("document.browse.links.active_link.colors.text", ses);
 	active_link.color.background = get_opt_color("document.browse.links.active_link.colors.background", ses);
+	active_link.insert_mode_color.foreground = get_opt_color("document.browse.links.active_link.insert_mode_colors.text", ses);
+	active_link.insert_mode_color.background = get_opt_color("document.browse.links.active_link.insert_mode_colors.background", ses);
 	active_link.enable_color = get_opt_bool("document.browse.links.active_link.enable_color", ses);
 	active_link.invert = get_opt_bool("document.browse.links.active_link.invert", ses);
 	active_link.underline = get_opt_bool("document.browse.links.active_link.underline", ses);

--- a/src/document/options.c
+++ b/src/document/options.c
@@ -48,6 +48,8 @@ init_document_options(struct session *ses, struct document_options *doo)
 
 	doo->active_link.color.foreground = get_opt_color("document.browse.links.active_link.colors.text", ses);
 	doo->active_link.color.background = get_opt_color("document.browse.links.active_link.colors.background", ses);
+	doo->active_link.insert_mode_color.foreground = get_opt_color("document.browse.links.active_link.insert_mode_colors.text", ses);
+	doo->active_link.insert_mode_color.background = get_opt_color("document.browse.links.active_link.insert_mode_colors.background", ses);
 
 	if (get_opt_bool("document.colors.increase_contrast", ses))
 		doo->color_flags |= COLOR_INCREASE_CONTRAST;

--- a/src/document/options.h
+++ b/src/document/options.h
@@ -20,6 +20,7 @@ struct active_link_options {
 	unsigned int bold:1;
 	unsigned int invert:1;
 	struct active_link_options_colors color;
+	struct active_link_options_colors insert_mode_color;
 };
 
 /** This mostly acts as a option cache so rendering will be faster. However it


### PR DESCRIPTION
The color is controlled by

  document.browse.links.active_link.insert_mode_colors.background
  document.browse.links.active_link.insert_mode_colors.text

Also avoid overloading local variable "i" in get_current_link().