### PR TITLE
Add preferred_document_width option.

### DIFF
--- a/src/config/actions-main.inc
+++ b/src/config/actions-main.inc
@@ -121,6 +121,7 @@ ACTION_(MAIN, "toggle-css", TOGGLE_CSS, N__("Toggle rendering of page using CSS"
 ACTION_(MAIN, "toggle-display-images", TOGGLE_DISPLAY_IMAGES, N__("Toggle displaying of links to images"), 0),
 ACTION_(MAIN, "toggle-display-tables", TOGGLE_DISPLAY_TABLES, N__("Toggle rendering of tables"), 0),
 ACTION_(MAIN, "toggle-document-colors", TOGGLE_DOCUMENT_COLORS, N__("Toggle usage of document specific colors"), 0),
+ACTION_(MAIN, "toggle-document-width", TOGGLE_DOCUMENT_WIDTH, N__("Toggle use of document width"), 0),
 ACTION_(MAIN, "toggle-html-plain", TOGGLE_HTML_PLAIN, N__("Toggle rendering page as HTML / plain text"), 0),
 ACTION_(MAIN, "toggle-mouse", TOGGLE_MOUSE, N__("Toggle mouse handling"), 0),
 ACTION_(MAIN, "toggle-numbered-links", TOGGLE_NUMBERED_LINKS, N__("Toggle displaying of links numbers"), 0),

--- a/src/config/kbdbind.c
+++ b/src/config/kbdbind.c
@@ -663,6 +663,7 @@ static struct default_kb default_main_keymap[] = {
 	{ { 'K',	 KBD_MOD_CTRL }, ACT_MAIN_COOKIES_LOAD },
 	{ { 'L',	 KBD_MOD_NONE }, ACT_MAIN_LINK_MENU },
 	{ { 'L',	 KBD_MOD_CTRL }, ACT_MAIN_REDRAW },
+	{ { 'M',	 KBD_MOD_NONE }, ACT_MAIN_TOGGLE_DOCUMENT_WIDTH },
 	{ { 'N',	 KBD_MOD_NONE }, ACT_MAIN_FIND_NEXT_BACK },
 	{ { 'N',	 KBD_MOD_CTRL }, ACT_MAIN_SCROLL_DOWN },
 	{ { 'P',	 KBD_MOD_CTRL }, ACT_MAIN_SCROLL_UP },

--- a/src/config/options.inc
+++ b/src/config/options.inc
@@ -463,6 +463,16 @@ static union option_info config_options_info[] = {
 		"margin_width", 0, 0, 9, 3,
 		N_("Horizontal text margin.")),
 
+	INIT_OPT_INT("document.browse", N_("Preferred document width"),
+		"preferred_document_width", 0, 0, 9999, 80,
+		N_("Try to fit the document within this width.  If set to zero,"
+		"use screen width.")),
+
+	INIT_OPT_BOOL("document.browse", N_("Whether to use preferred document width"),
+		"use_preferred_document_width", 0, 1,
+		N_("Whether to use preferred document width.  If set to zero,\n"
+		"use screen width.  If set to one, use preferred_document_width.")),
+
 	INIT_OPT_BOOL("document.browse", N_("Document meta refresh"),
 		"refresh", 0, 1,
 		N_("Automatically follow document-specified refresh "

--- a/src/document/html/parser.c
+++ b/src/document/html/parser.c
@@ -804,7 +804,7 @@ init_html_parser(struct uri *uri, struct document_options *options,
 	par_format.leftmargin = options->margin;
 	par_format.rightmargin = options->margin;
 
-	par_format.width = options->box.width;
+	par_format.width = options->document_width;
 	par_format.list_level = par_format.list_number = 0;
 	par_format.dd_margin = options->margin;
 	par_format.flags = P_DISC;

--- a/src/document/html/parser/forms.c
+++ b/src/document/html/parser/forms.c
@@ -316,8 +316,8 @@ html_input(struct html_context *html_context, unsigned char *a,
 	if (fc->size == -1)
 		fc->size = html_context->options->default_form_input_size;
 	fc->size++;
-	if (fc->size > html_context->options->box.width)
-		fc->size = html_context->options->box.width;
+	if (fc->size > html_context->options->document_width)
+		fc->size = html_context->options->document_width;
 	fc->maxlength = get_num(a, "maxlength", cp);
 	if (fc->maxlength == -1) fc->maxlength = INT_MAX;
 	if (fc->type == FC_CHECKBOX || fc->type == FC_RADIO)
@@ -678,8 +678,8 @@ pp:
 		cols = html_context->options->default_form_input_size;
 	cols++; /* Add 1 column, other browsers may have different
 		   behavior here (mozilla adds 2) --Zas */
-	if (cols > html_context->options->box.width)
-		cols = html_context->options->box.width;
+	if (cols > html_context->options->document_width)
+		cols = html_context->options->document_width;
 	fc->cols = cols;
 
 	rows = get_num(attr, "rows", html_context->doc_cp);

--- a/src/document/html/parser/general.c
+++ b/src/document/html/parser/general.c
@@ -1080,7 +1080,7 @@ html_frameset(struct html_context *html_context, unsigned char *a,
 	}
 
 	if (!html_top->frameset) {
-		width = html_context->options->box.width;
+		width = html_context->options->document_width;
 		height = html_context->options->box.height;
 		html_context->options->needs_height = 1;
 	} else {

--- a/src/document/html/renderer.c
+++ b/src/document/html/renderer.c
@@ -1013,7 +1013,7 @@ del_chars(struct html_context *html_context, int x, int y)
 # define overlap_width(x) (x).width
 #else
 # define overlap_width(x) int_min((x).width, \
-	html_context->options->box.width - TABLE_LINE_PADDING)
+	html_context->options->document_width - TABLE_LINE_PADDING)
 #endif
 #define overlap(x) int_max(overlap_width(x) - (x).rightmargin, 0)
 
@@ -2557,7 +2557,7 @@ render_html_document(struct cache_entry *cached, struct document *document,
 
 	part = format_html_part(html_context, start, end, par_format.align,
 			        par_format.leftmargin,
-				document->options.box.width, document,
+				document->options.document_width, document,
 			        0, 0, head.source, 1);
 
 	/* Drop empty allocated lines at end of document if any

--- a/src/document/options.c
+++ b/src/document/options.c
@@ -32,6 +32,20 @@ init_document_options(struct session *ses, struct document_options *doo)
 
 	doo->use_document_colors = get_opt_int("document.colors.use_document_colors", ses);
 	doo->margin = get_opt_int("document.browse.margin_width", ses);
+
+	doo->document_width = 0;
+	if (get_opt_bool("document.browse.use_preferred_document_width", ses))
+		doo->document_width = get_opt_int("document.browse.preferred_document_width", ses);
+
+	if (ses) {
+		if (doo->document_width <= 0 || doo->document_width > ses->tab->term->width)
+			doo->document_width = ses->tab->term->width;
+	} else {
+		/* Assume we are in -dump mode.  Should we consolidate
+		 * document.dump.width with document.browse.preferred_document_width ? */
+		doo->document_width = get_opt_int("document.dump.width", NULL);
+	}
+
 	doo->num_links_key = get_opt_int("document.browse.links.number_keys_select_link", ses);
 	doo->meta_link_display = get_opt_int("document.html.link_display", ses);
 	doo->default_form_input_size = get_opt_int("document.browse.forms.input_size", ses);

--- a/src/document/options.h
+++ b/src/document/options.h
@@ -55,6 +55,7 @@ struct document_options {
 	int use_document_colors;
 	int meta_link_display;
 	int default_form_input_size;
+	int document_width;
 
 	/** @name The default (fallback) colors.
 	 * @{ */

--- a/src/document/plain/renderer.c
+++ b/src/document/plain/renderer.c
@@ -724,7 +724,7 @@ render_plain_document(struct cache_entry *cached, struct document *document,
 	renderer.lineno = 0;
 	renderer.convert_table = convert_table;
 	renderer.compress = document->options.plain_compress_empty_lines;
-	renderer.max_width = document->options.wrap ? document->options.box.width
+	renderer.max_width = document->options.wrap ? document->options.document_width
 						    : INT_MAX;
 
 	document->color.background = document->options.default_style.color.background;

--- a/src/viewer/action.c
+++ b/src/viewer/action.c
@@ -610,6 +610,11 @@ do_action(struct session *ses, enum main_action action_id, int verbose)
 			toggle_document_option(ses, "document.colors.use_document_colors");
 			break;
 
+		case ACT_MAIN_TOGGLE_DOCUMENT_WIDTH:
+			toggle_document_option(ses, "document.browse.use_preferred_document_width");
+			redraw_terminal_cls(term);
+			break;
+
 		case ACT_MAIN_TOGGLE_HTML_PLAIN:
 			toggle_plain_html(ses, ses->doc_view, 0);
 			break;


### PR DESCRIPTION
Option document.browse.preferred_document_width controls the
width of the document, so that documents are rendered with narrower
width than screen width.  Makes it easier to read paragraphs.

Patch originally from Shalon Wood <dstar@pele.cx>, see bug #1063.

Instead of using max_document_width as the hard limit to the document
width, it uses a soft limit, where if the document does not fit (due to
tables, etc.), then larger width is used.  This reduces the need for
horizontal scrolling for wide documents.

Also added toggle-document-width action to toggle between preferred
width and full screen width.  This is bound to 'M' by default.  Initial
toggle status is determined by document.browse.use_preferred_document_width
option.

During dumps, document.dump.width option is still used.  Perhaps we
should consolidate document.dump.width option with
document.browse.preferred_document_width ?