### PR TITLE
when searching in a node, only search within its box

### DIFF
--- a/src/viewer/text/search.c
+++ b/src/viewer/text/search.c
@@ -153,12 +153,13 @@ get_srch(struct document *document)
 
 	foreachback (node, document->nodes) {
 		int x, y;
-		int height = document->height;
+		int height = int_min(node->box.y + node->box.height, document->height);
 
 		for (y = node->box.y; y < height; y++) {
-			int width = document->data[y].length;
+			int width = int_min(node->box.x + node->box.width,
+			                    document->data[y].length);
 
-			for (x = 0;
+			for (x = node->box.x;
 			     x < width && document->data[y].chars[x].data <= ' ';
 			     x++);
 


### PR DESCRIPTION
This commit solves the out-of-memory issue in #21.

It does it by making get_srch() only add the characters in the box of each node to add_srch_chr(), instead of everything from the start of the node to the end of the document. The data structure created this way may be very large, since it contains the characters in the document replicated many times.

This commit reverts the change in this function by 7a006b6dd21b12fb47b3c968d309a3c99e1117e1.

