### PR TITLE
Compat with gnutls 3.6.4

### DIFF
--- a/src/network/ssl/ssl.c
+++ b/src/network/ssl/ssl.c
@@ -392,7 +392,7 @@ init_ssl_connection(struct socket *socket,
 	 * in ELinks.  If you change the priorities here, please check
 	 * whether that one needs to be changed as well.  */
 	if (gnutls_priority_set_direct(*state,
-				       "NORMAL:-CTYPE-OPENPGP:-VERS-TLS1.1:-VERS-SSL3.0",
+				       "NORMAL:-VERS-TLS1.1:-VERS-SSL3.0",
 				       NULL)) {
 		gnutls_deinit(*state);
 		mem_free(state);


### PR DESCRIPTION
This ;atch was used jn Debian for elinks 0.12pre6. It might not be necessary 
when linking against GNUTLS 3.6.5

 With GNUTLS 3.6.x, elinks gives the following SSL error:

 $ elinks -dump https://google.com
 ELinks: SSL error


The issue is that ELinks does:

 gnutls_priority_set_direct(*state, "NORMAL:-CTYPE-OPENPGP", NULL)

 which used to pass fine in 3.5. (aka use normal, but disable OPENPGP
 certs), with with 3.6 this errors out, because OPENPGP certs are
 deleted.

 Someone suggested that elinks should simply use gnutls_set_default_priority()
 instead of gnutls_priority_set_direct(). See: https://bugs.debian.org/910862

