### PR TITLE
add -remote 'search(string)'

### DIFF
--- a/src/config/cmdline.c
+++ b/src/config/cmdline.c
@@ -205,6 +205,7 @@ enum remote_method_enum {
 	REMOTE_METHOD_ADDBOOKMARK,
 	REMOTE_METHOD_INFOBOX,
 	REMOTE_METHOD_RELOAD,
+	REMOTE_METHOD_SEARCH,
 	REMOTE_METHOD_NOT_SUPPORTED,
 };
 
@@ -223,6 +224,7 @@ remote_cmd(struct option *o, unsigned char ***argv, int *argc)
 		{ "infoBox",	  REMOTE_METHOD_INFOBOX },
 		{ "xfeDoCommand", REMOTE_METHOD_XFEDOCOMMAND },
 		{ "reload",	  REMOTE_METHOD_RELOAD },
+		{ "search",	  REMOTE_METHOD_SEARCH },
 		{ NULL,		  REMOTE_METHOD_NOT_SUPPORTED },
 	};
 	unsigned char *command, *arg, *argend, *argstring;
@@ -390,6 +392,16 @@ remote_cmd(struct option *o, unsigned char ***argv, int *argc)
 
 	case REMOTE_METHOD_RELOAD:
 		remote_session_flags = SES_REMOTE_RELOAD;
+		break;
+
+	case REMOTE_METHOD_SEARCH:
+		if (remote_argc < 1)
+			remote_url = stracpy("");
+		else
+			remote_url = stracpy(remote_argv[0]);
+		insert_in_string(&remote_url, 0,
+				 "search:", sizeof("search:") - 1);
+		remote_session_flags = SES_REMOTE_SEARCH;
 		break;
 
 	case REMOTE_METHOD_NOT_SUPPORTED:

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -55,6 +55,7 @@
 #include "viewer/text/form.h"
 #include "viewer/text/link.h"
 #include "viewer/text/view.h"
+#include "viewer/text/search.h"
 
 
 struct file_to_load {
@@ -1052,9 +1053,19 @@ init_remote_session(struct session *ses, enum remote_session_flags *remote_ptr,
 
 	} else if (remote & SES_REMOTE_PROMPT_URL) {
 		dialog_goto_url_open(ses);
-
 	} else if (remote & SES_REMOTE_RELOAD) {
 		reload(ses, CACHE_MODE_FORCE_RELOAD);
+	} else if (remote & SES_REMOTE_SEARCH) {
+		if (!uri)
+			return;
+		if (strncmp(uri->string, "search:", sizeof("search:") - 1)) {
+			info_box(ses->tab->term, MSGBOX_FREE_TEXT,
+				 N_("Incorrect search uri"), ALIGN_CENTER,
+				 uri->string);
+			return;
+		}
+
+		search_for(ses, uri->data);
 	}
 }
 

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -36,6 +36,7 @@ enum remote_session_flags {
 	SES_REMOTE_ADD_BOOKMARK = 32,
 	SES_REMOTE_INFO_BOX = 64,
 	SES_REMOTE_RELOAD = 128,
+	SES_REMOTE_SEARCH = 256,
 };
 
 /** This is generic frame descriptor, meaningful mainly for ses_*_frame*(). */

--- a/src/viewer/text/search.c
+++ b/src/viewer/text/search.c
@@ -1032,7 +1032,7 @@ search_for_back(struct session *ses, unsigned char *str)
 	search_for_do(ses, str, -1, 1);
 }
 
-static void
+void
 search_for(struct session *ses, unsigned char *str)
 {
 	assert(ses && str);

--- a/src/viewer/text/search.h
+++ b/src/viewer/text/search.h
@@ -18,7 +18,7 @@ enum frame_event_status find_next(struct session *ses, struct document_view *doc
 enum frame_event_status move_search_next(struct session *ses, struct document_view *doc_view);
 enum frame_event_status move_search_prev(struct session *ses, struct document_view *doc_view);
 
-
+void search_for(struct session *ses, unsigned char *str);
 enum frame_event_status search_dlg(struct session *ses, struct document_view *doc_view, int direction);
 enum frame_event_status search_typeahead(struct session *ses, struct document_view *doc_view, action_id_T action_id);
 


### PR DESCRIPTION
This commit add the remote command search(string) for searching a string in the document. Passing no string is equivalent to searching for the empty string, that is, clears the selection of the previously found string, if any.