### PR TITLE
document the -remote search(string) function

### DIFF
--- a/doc/man/man1/elinks.1.in
+++ b/doc/man/man1/elinks.1.in
@@ -211,6 +211,10 @@ Following is a list of the supported methods:
 .RE
 .sp
 .RS 4
+\h'-04'\(bu\h'+03'\fBsearch(\fR\fBstring\fR\fB)\fR: search in the current tab
+.RE
+.sp
+.RS 4
 \h'-04'\(bu\h'+03'\fBxfeDoCommand(\fR\fBopenBrowser\fR\fB)\fR: open new window
 .RE
 .RE

--- a/doc/remote.txt
+++ b/doc/remote.txt
@@ -77,6 +77,7 @@ Command				Description
 addBookmark(URL)		Bookmarks the passed URL.
 infoBox(text)			Show text in a message box.
 reload()			Reload the document in the current tab.
+search(string)			Search for the string in the current tab
 -------------------------------------------------------------------------------
 
 `-remote` can also take a list of URLs without an explicit action, in which case


### PR DESCRIPTION
This commit documents my previous PR.

I updated remote.txt and the man page. I guess these are the only two places where to document. There is no online help for the specific commands that can be passed via -remote, is there?