### PR TITLE
config option for disabling the mouse

### DIFF
--- a/src/config/options.inc
+++ b/src/config/options.inc
@@ -1465,6 +1465,14 @@ static union option_info config_options_info[] = {
 		N_("Date format to use in dialogs. See strftime(3).")),
 #endif
 
+#ifdef CONFIG_MOUSE
+	/* date added */
+	INIT_OPT_BOOL("ui", N_("Disable mouse"),
+		"mouse_disable", 0, 0,
+		N_("Disable mouse. "
+		"Changes take effect at the next elinks restart.")),
+#endif
+
 	INIT_OPT_BOOL("ui", N_("Set window title"),
 		"window_title", 0, 1,
 		N_("Set the window title when running in a windowing "

--- a/src/terminal/mouse.c
+++ b/src/terminal/mouse.c
@@ -89,6 +89,9 @@ enable_mouse(void)
 {
 	int h = get_output_handle(); /* XXX: Is this all right? -- Miciah */
 
+	if (get_opt_bool("ui.mouse_disable", NULL))
+		return;
+
 	if (mouse_enabled) return;
 
 	if (is_xterm()) send_mouse_init_sequence(h);


### PR DESCRIPTION
Disabling mouse support is useful if one does not want to use the mouse for the elinks UI but prefers gpm selection to be possible without pressing ctrl. Yet, mouse support can only be disabled at compile time, which means that if one uses elinks from a distribution this is not possible.

This merge request introduces a config variable for disabling the mouse.

In order for selection to be possible without pressing control, mouse initialization has to be skipped altogther. The change is relatively small if disabling or enabling the mouse only takes place at the next restart of elinks. Otherwise, there should be a mechanism for initializing or closing the mouse at
runtime. I don't know if this is worth the effort.
