### PR TITLE
show an alert when the search string is not found

### DIFF
--- a/src/viewer/text/search.c
+++ b/src/viewer/text/search.c
@@ -991,6 +991,7 @@ search_for_do(struct session *ses, unsigned char *str, int direction,
 {
 	struct document_view *doc_view;
         int utf8 = 0;
+	enum find_error error;
 
 	assert(ses && str);
 	if_assert_failed return FIND_ERROR_NOT_FOUND;
@@ -1019,8 +1020,13 @@ search_for_do(struct session *ses, unsigned char *str, int direction,
 	if (!ses->last_search_word) return FIND_ERROR_NOT_FOUND;
 	ses->search_direction = direction;
 
-	return get_searched_all(ses, doc_view, &doc_view->document->search_points,
+	error = get_searched_all(ses, doc_view, &doc_view->document->search_points,
 		&doc_view->document->number_of_search_points, utf8);
+
+	if (report_errors && error == FIND_ERROR_NOT_FOUND)
+		print_find_error(ses, error);
+
+	return error;
 }
 
 static void


### PR DESCRIPTION
elinks used to signal when the search string was not found in the document. This commit restores that behaviour, in almost the same way it was done before.

This change unveiled another problem: function ``move_search_do()`` returns an ``enum frame_event_status``, but this return value is then returned as is by the calling function ``get_searched_all()``, which however returns an ``enum find_error``.

This is the reason why I had to check ``error == FIND_ERROR_NOT_FOUND``, which wasn't in the original elinks code and shouldn't be necessary.
