### PR TITLE
Let requests default to https

### DIFF
--- a/doc/man/man5/elinks.conf.5
+++ b/doc/man/man5/elinks.conf.5
@@ -203,6 +203,11 @@ connection\&.ssl\&.cert_verify \fB[0|1]\fR (default: 0)
 .RS 4
 Verify the peer\'s SSL certificate\&. Note that this needs extensive configuration of OpenSSL by the user\&.
 .RE
+.PP
+connection\&.ssl\&.https_by_default \fB[0|1]\fR (default: 0)
+.RS 4
+Use HTTPS when a URL scheme is not provided\&.
+.RE
 .SS "connection\&.ssl\&.client_cert (Client Certificates)"
 X509 client certificate options\&.
 .PP

--- a/src/network/ssl/ssl.c
+++ b/src/network/ssl/ssl.c
@@ -118,6 +118,10 @@ static union option_info openssl_options[] = {
 		N_("Verify the peer's SSL certificate. Note that this "
 		"needs extensive configuration of OpenSSL by the user.")),
 
+	INIT_OPT_BOOL("connection.ssl", N_("Use HTTPS by default"),
+		"https_by_default", 0, 0,
+		N_("Use HTTPS when a URL scheme is not provided.")),
+
 	INIT_OPT_TREE("connection.ssl", N_("Client Certificates"),
         	"client_cert", OPT_SORT,
         	N_("X509 client certificate options.")),

--- a/src/protocol/uri.c
+++ b/src/protocol/uri.c
@@ -1242,6 +1242,11 @@ parse_uri:
 				break;
 
 			case PROTOCOL_HTTP:
+#ifdef CONFIG_SSL
+				if (get_opt_bool("connection.ssl.https_by_default", NULL))
+					add_to_string(&str, "https://");
+				else
+#endif
 				add_to_string(&str, "http://");
 				add_to_string(&str, newurl);
 				break;


### PR DESCRIPTION
As most websites now use https making an initial http request for every url path you type is slow and insecure.