### PR TITLE
Enable true colors in the default build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1439,7 +1439,7 @@ EL_ARG_ENABLE(CONFIG_256_COLORS, 256-colors, [256 colors],
 	      [  --enable-256-colors     enable 256 color support])
 
 EL_ARG_ENABLE(CONFIG_TRUE_COLOR, true-color, [true color],
-	      [  --enable-true-color     enable true color support])
+	      [  --disable-true-color    disable true color support])
 
 EL_ARG_ENABLE(CONFIG_EXMODE, exmode, [Exmode interface],
 	      [  --enable-exmode         enable exmode (CLI) interface])

--- a/features.conf
+++ b/features.conf
@@ -547,12 +547,11 @@ CONFIG_256_COLORS=no
 
 ### True color
 #
-# Define to add support for True color. Note that only terminal capable to show
-# it is konsole from kdebase-3.5.4. This mode eats a lot of memory.
+# Define to add support for True color. This mode eats a lot of memory.
 #
-# Default: disabled
+# Default: enabled
 
-CONFIG_TRUE_COLOR=no
+CONFIG_TRUE_COLOR=yes
 
 ### Terminfo
 #


### PR DESCRIPTION
Modern terminals generally support true colors.