### PR TITLE
also pass the uri as %u to external handlers

### DIFF
--- a/doc/mime.txt
+++ b/doc/mime.txt
@@ -91,7 +91,8 @@ choice if you want).
 Attaching a program to it::
 
 	You must tell ELinks the exact command for running it (with any
-	options you wish). In place of the filename you must enter %.
+	options you wish). In place of the filename you must enter %f. Also the
+	uri can be used as %u.
 
 Choosing whether you want confirmation before applying it::
 
@@ -144,12 +145,12 @@ and value with the value you want to assign to the item. You must do so for
 each of the available items: program, ask and block.
 
 The value for program is a string with the exact command you want to be issued
-to view the file, placing % were you would put the file name. The values for
-ask and block are either 0 (no) or 1 (yes). Available contexts include unix
-and unix-xwin, which mean UNIX text terminal and X respectively (others can be
-os2, win32, beos, riscos, ...). The latter does not mean you are running
-ELinks from X, just that the DISPLAY variable is set so that ELinks may run an
-X program.
+to view the file, placing %f were you would put the file name and %u the uri
+(if needed). The values for ask and block are either 0 (no) or 1 (yes).
+Available contexts include unix and unix-xwin, which mean UNIX text terminal
+and X respectively (others can be os2, win32, beos, riscos, ...). The latter
+does not mean you are running ELinks from X, just that the DISPLAY variable is
+set so that ELinks may run an X program.
 
 To illustrate it, here is an example. Suppose you want to define the
 image_viewer handler which should be used to view images.  The configuration
@@ -162,8 +163,8 @@ set mime.handler.image_viewer.unix-xwin.ask = 0
 set mime.handler.image_viewer.unix.block = 1
 set mime.handler.image_viewer.unix-xwin.block = 0
 
-set mime.handler.image_viewer.unix.program = "zgv %"
-set mime.handler.image_viewer.unix-xwin.program = "xli %"
+set mime.handler.image_viewer.unix.program = "zgv %f"
+set mime.handler.image_viewer.unix-xwin.program = "xli %f"
 --------------------------------------------------------------------------------
 
 In this example the image_viewer handler uses the svgalib image viewer zgv

--- a/src/mime/backend/default.c
+++ b/src/mime/backend/default.c
@@ -74,7 +74,8 @@ static union option_info default_mime_options[] = {
 		"program", 0, "",
 		/* xgettext:no-c-format */
 		N_("External viewer for this file type. "
-		"'%' in this string will be substituted by a file name. "
+		"'%f' in this string will be substituted by a file name, "
+		"'%u' by its uri. "
 		"Do _not_ put single- or double-quotes around the % sign.")),
 
 


### PR DESCRIPTION
Most if not all browsers allow viewing an image by itself. When they do, they show the image url in the address bar. The corresponding operation in elinks   is to open the image with an external handler. Many image viewers show or let the user show the image name, but this is the name of the temporary file elinks downloaded the image to, not the uri. Some image viewers accept an   image title to be shown instead or in addition to the file name: feh has the --info option, gwenview has --title, fbv has -n. Passing the image uri makes them produce the expected behaviour.

This commit changes the format of the handler string: %u stands for the uri, in addition to %f for the local file name. The old syntax is still accepted since % followed by space or the end of the string is replaced by the file name. The commit also allows `%%` to mean an actual percent symbol, which was   previously impossible.

In case of images also passing the `alt` tag would make sense, but I believe that would be complicated because it requires passing the content of that tag around until the point where the handler string is substituted.

