### PR TITLE
Fix compilation with gcc-10

### DIFF
--- a/src/scripting/ruby/core.h
+++ b/src/scripting/ruby/core.h
@@ -21,7 +21,7 @@ struct session;
 #define RB_ERRINFO (ruby_errinfo)
 #endif
 
-VALUE erb_module;
+extern VALUE erb_module;
 
 void alert_ruby_error(struct session *ses, unsigned char *msg);
 void erb_report_error(struct session *ses, int state);


### PR DESCRIPTION
Fixes the errors

x86_64-pc-linux-gnu-ld: hooks.o:(.bss+0x0): multiple definition of `erb_module'; core.o:(.bss+0x0): first defined here
x86_64-pc-linux-gnu-ld: ruby.o:(.bss+0x0): multiple definition of `erb_module'; core.o:(.bss+0x0): first defined here

Bug: https://bugs.gentoo.org/730658