### PR TITLE
update the "What to do?" dialog to the new format with %f for the file

### DIFF
--- a/src/mime/backend/mailcap.c
+++ b/src/mime/backend/mailcap.c
@@ -517,7 +517,7 @@ format_command(unsigned char *command, unsigned char *type, int copiousoutput)
 			command++;
 			if (!strncmp(command, "%s'", 3)) {
 				command += 3;
-				add_char_to_string(&cmd, '%');
+				add_to_string(&cmd, "%f");
 			} else {
 				add_char_to_string(&cmd, '\'');
 			}
@@ -530,7 +530,7 @@ format_command(unsigned char *command, unsigned char *type, int copiousoutput)
 				return NULL;
 
 			} else if (*command == 's') {
-				add_char_to_string(&cmd, '%');
+				add_to_string(&cmd, "%f");
 
 			} else if (*command == 't') {
 				if (!type) {

--- a/src/session/download.c
+++ b/src/session/download.c
@@ -1627,7 +1627,9 @@ do_type_query(struct type_query *type_query, unsigned char *ct, struct mime_hand
 		}
 
 		/* xgettext:no-c-format */
-		add_dlg_field(dlg, _("Program ('%' will be replaced by the filename)", term),
+		add_dlg_field(dlg,
+			_("Program ('%f' will be replaced by the filename, "
+			  "'%u' by the uri)", term),
 			0, 0, NULL, MAX_STR_LEN, field, NULL);
 		type_query->external_handler = field;
 


### PR DESCRIPTION
The "what do to?" dialog uses %f and %u, so better have that shown to the user.