### PR TITLE
do not display downloads of protocol "data:"

### DIFF
--- a/src/dialogs/download.c
+++ b/src/dialogs/download.c
@@ -238,6 +238,9 @@ display_download(struct terminal *term, struct file_download *file_download,
 	if (!is_in_downloads_list(file_download))
 		return;
 
+	if (file_download->uri->protocol == PROTOCOL_DATA)
+		return;
+
 #ifdef CONFIG_BITTORRENT
 #define DOWNLOAD_WIDGETS_COUNT 5
 #else


### PR DESCRIPTION
Downloading of large data: uri was slow. This commit is a quick fix to that.

Whether "downloading" of data: uri is a real download to be shown in the downloading window is arguable.
