### PR TITLE
truncate data: uri passed to the external viewer

### DIFF
--- a/src/session/download.c
+++ b/src/session/download.c
@@ -1054,7 +1054,7 @@ subst_file(unsigned char *prog, unsigned char *file, unsigned char *uri)
 				replace = file;
 			else if (*prog == 'u') {
 				replace = uri;
-				if (! memcmp(uri, "data:", strlen("data:")))
+				if (!memcmp(uri, "data:", sizeof("data:") - 1))
 					truncate = 1;
 			}
 			else if (*prog == '%')
@@ -1083,7 +1083,8 @@ subst_file(unsigned char *prog, unsigned char *file, unsigned char *uri)
 					strlen(replace));
 			else {
 				add_shell_quoted_to_string(&name, replace, 40);
-				add_shell_quoted_to_string(&name, "...", 3);
+				add_shell_quoted_to_string(&name,
+					"...", sizeof("...") - 1);
 			}
 #endif
 			prog++;

--- a/src/session/download.c
+++ b/src/session/download.c
@@ -1036,6 +1036,7 @@ subst_file(unsigned char *prog, unsigned char *file, unsigned char *uri)
 	int input = 1;
 	char *replace, *original = "% ";
 	int truncate;
+	int tlen = 40;
 
 	if (!init_string(&name)) return NULL;
 
@@ -1078,11 +1079,12 @@ subst_file(unsigned char *prog, unsigned char *file, unsigned char *uri)
 			cygwin_conv_to_full_win32_path(replace, new_path);
 			add_to_string(&name, new_path);
 #else
-			if (! truncate)
-				add_shell_quoted_to_string(&name, replace,
-					strlen(replace));
+			if (! truncate || strlen(replace) <= tlen)
+				add_shell_quoted_to_string(&name,
+					replace, strlen(replace));
 			else {
-				add_shell_quoted_to_string(&name, replace, 40);
+				add_shell_quoted_to_string(&name,
+					replace, tlen);
 				add_shell_quoted_to_string(&name,
 					"...", sizeof("...") - 1);
 			}


### PR DESCRIPTION
When calling an external viewer, the whole uri replaces %u in the command string. If the uri is of data: scheme, it is not only useless but may also be very long since it encodes the whole content of the image.

This commit truncates it to 40 characters and adds "..." at its end. This is enough to show the data:part, the type and the encoding, which are the only parts that may be of some interest to the user.