### PR TITLE
meaningful default save name for data: uri content

### DIFF
--- a/src/protocol/uri.c
+++ b/src/protocol/uri.c
@@ -613,10 +613,11 @@ add_uri_to_string(struct string *string, const struct uri *uri,
 
 		if (uri->protocol == PROTOCOL_DATA) {
 			char *e;
-			add_bytes_to_string(string,
-				"data", sizeof("data") - 1);
+			add_to_string(string, "data");
 			e = get_extension_from_uri((struct uri *) uri);
-			return add_bytes_to_string(string, e, strlen(e));
+			add_to_string(string, e);
+			mem_free(e);
+			return string;
 		}
 
 		for (pos = filename; *pos && !end_of_dir(*pos); pos++)
@@ -1327,7 +1328,7 @@ get_translated_uri(unsigned char *uristring, unsigned char *cwd)
 #define ADD_EXTENSION_FROM_TYPE(string, type, ext)			\
 	if (!memcmp(uri->data, type ";", sizeof(type ";") - 1)	||	\
 	    !memcmp(uri->data, type ",", sizeof(type ",") - 1))		\
-		return strdup("." ext);
+		return stracpy("." ext);
 
 unsigned char *
 get_extension_from_uri(struct uri *uri)
@@ -1344,7 +1345,7 @@ get_extension_from_uri(struct uri *uri)
 		ADD_EXTENSION_FROM_TYPE(uri->data, "image/png",  "png")
 		ADD_EXTENSION_FROM_TYPE(uri->data, "text/plain", "txt")
 		ADD_EXTENSION_FROM_TYPE(uri->data, "text/html",  "html")
-		return "";
+		return stracpy("");
 	}
 
 	for (; *pos && !end_of_dir(*pos); pos++) {

--- a/src/protocol/uri.c
+++ b/src/protocol/uri.c
@@ -611,6 +611,14 @@ add_uri_to_string(struct string *string, const struct uri *uri,
 
 		if (!uri->datalen) return string;
 
+		if (uri->protocol == PROTOCOL_DATA) {
+			char *e;
+			add_bytes_to_string(string,
+				"data", sizeof("data") - 1);
+			e = get_extension_from_uri((struct uri *) uri);
+			return add_bytes_to_string(string, e, strlen(e));
+		}
+
 		for (pos = filename; *pos && !end_of_dir(*pos); pos++)
 			if (wants(URI_FILENAME) && is_uri_dir_sep(uri, *pos))
 				filename = pos + 1;
@@ -1316,6 +1324,10 @@ get_translated_uri(unsigned char *uristring, unsigned char *cwd)
 	return uri;
 }
 
+#define ADD_EXTENSION_FROM_TYPE(string, type, ext)			\
+	if (!memcmp(uri->data, type ";", sizeof(type ";") - 1)	||	\
+	    !memcmp(uri->data, type ",", sizeof(type ",") - 1))		\
+		return strdup("." ext);
 
 unsigned char *
 get_extension_from_uri(struct uri *uri)
@@ -1325,6 +1337,15 @@ get_extension_from_uri(struct uri *uri)
 	unsigned char *pos = uri->data;
 
 	assert(pos);
+
+	if (uri->protocol == PROTOCOL_DATA) {
+		ADD_EXTENSION_FROM_TYPE(uri->data, "image/gif",  "gif")
+		ADD_EXTENSION_FROM_TYPE(uri->data, "image/jpeg", "jpg")
+		ADD_EXTENSION_FROM_TYPE(uri->data, "image/png",  "png")
+		ADD_EXTENSION_FROM_TYPE(uri->data, "text/plain", "txt")
+		ADD_EXTENSION_FROM_TYPE(uri->data, "text/html",  "html")
+		return "";
+	}
 
 	for (; *pos && !end_of_dir(*pos); pos++) {
 		if (!afterslash && !extension && *pos == '.') {


### PR DESCRIPTION
The default name of the file an image is saved to is the last part of the uri, everything that follows the last slash in it. In case of a data: uri, this results in a random-looking sequence of characters. This commit turns that to "data", possibly followed by the file extension if the mime type is recognized to the be one of the typical ones: jpeg, gif, png, txt or html.

I do not like much the use of the ADD_EXTENSION_FROM_TYPE() macro sequence rather than looking up the default extension from /etc/mimetypes, but is coherent with the similar strategy used in mime/backend/default.c

Here are some testing files: [data.zip](https://github.com/rkd77/felinks/files/5294255/data.zip)
